### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/lequochuy134/c3ac37f9-170c-4a51-9d5e-fc543ab0ff8d/9ad4546c-f852-488e-ac13-b658122cf56d/_apis/work/boardbadge/2d2f64af-31bb-4ce4-b87f-3ede6480659d)](https://dev.azure.com/lequochuy134/c3ac37f9-170c-4a51-9d5e-fc543ab0ff8d/_boards/board/t/9ad4546c-f852-488e-ac13-b658122cf56d/Microsoft.RequirementCategory)
 <h1 align="center">
   <img src="https://ipsw.me/assets/images/brand/racer.png"><br>
   canijailbreak.com


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/lequochuy134/c3ac37f9-170c-4a51-9d5e-fc543ab0ff8d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.